### PR TITLE
overrides _createActorSearchView() instead of startup()

### DIFF
--- a/utils/ActorSelection.js
+++ b/utils/ActorSelection.js
@@ -15,7 +15,7 @@ define([
             this.inherited(arguments);
         },
 
-        startup: function () {
+        _createActorSearchView: function () {
             console.log('..ActorSelection::startup', arguments);
             this.inherited(arguments);
 


### PR DESCRIPTION
fix #63 